### PR TITLE
ofp4: add safety stop for actions

### DIFF
--- a/ofpstr/ofp4.py
+++ b/ofpstr/ofp4.py
@@ -383,6 +383,8 @@ def str2dict(s, defaults={}):
 				s = s[l:]
 		elif phase == PHASE_ACTION:
 			act, l = str2act(s)
+			if l == 0:
+				raise ValueError("unknown action {:s}".format(s))
 			actions += act
 			s = s[l:]
 		else:


### PR DESCRIPTION
on `ofp4.str2mod`, infinite loop occurred when invalid actions such as `'in_port=1,@apply,output:'` are specified.
